### PR TITLE
Remove unneeded #![feature] attributes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-webvr"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Imanol Fernandez <mortimergoro@gmail.com>"]
 
 homepage = "https://github.com/MortimerGoro/rust-webvr"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,3 @@
-#![feature(custom_attribute)]
-#![feature(custom_derive)]
-#![cfg_attr(feature = "openvr", feature(untagged_unions))]
-
 #[macro_use]
 macro_rules! identity_matrix {
     () => ([1.0, 0.0, 0.0, 0.0,  0.0, 1.0, 0.0, 0.0,  0.0, 0.0, 1.0, 0.0,  0.0, 0.0, 0.0, 1.0]);


### PR DESCRIPTION
Custom derive is now stable, and unions are not used. This change allows compiling this crate on Rust Stable.