### PR TITLE
room example: allow to run the example if direct_draw is not available.

### DIFF
--- a/examples/room/src/main.rs
+++ b/examples/room/src/main.rs
@@ -539,7 +539,7 @@ pub fn main() {
     display.borrow_mut().start_present(Some(attributes));
 
     let vr_fbos = display.borrow().get_framebuffers();
-    assert!(vr_fbos.len() > 0);
+    assert!(!direct_draw || vr_fbos.len() > 0);
 
     if multiview && !vr_fbos.first().unwrap().attributes.multiview {
         panic!("Multiview not supported in this Device");


### PR DESCRIPTION
We ran into a couple of issues trying to run the example on a valve
index.
It turns out openvr get_framebuffers() returns an empty vec, and
an assertion would fail.
This happens because direct_draw is not available, which doesn't
prevent the example from running.